### PR TITLE
Fix: サーボ関係の初期化関数の微修正

### DIFF
--- a/Arduino/App_LightMeter/Servo.ino
+++ b/Arduino/App_LightMeter/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;	// servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	// servo.servo.attach(PIN_SRV);
 	SRV_Attach();

--- a/Arduino/ProgrammingTutorial09_Device3/Servo.ino
+++ b/Arduino/ProgrammingTutorial09_Device3/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;	// servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/ProgrammingTutorial10_Application/Servo.ino
+++ b/Arduino/ProgrammingTutorial10_Application/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;	// servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	// servo.servo.attach(PIN_SRV);
 	SRV_Attach();

--- a/Arduino/Test/Servo.ino
+++ b/Arduino/Test/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 1;
+	servo.setPosition = 1;	// servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test/Servo.ino
+++ b/Arduino/Test/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test_Servo/Servo.ino
+++ b/Arduino/Test_Servo/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test_Servo/Servo.ino
+++ b/Arduino/Test_Servo/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 1;
+	servo.setPosition = 1; 	// servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test_Servo_x2/Servo.ino
+++ b/Arduino/Test_Servo_x2/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 1;
+	servo.setPosition = 1;  // servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test_Servo_x2/Servo.ino
+++ b/Arduino/Test_Servo_x2/Servo.ino
@@ -5,7 +5,7 @@ Servo_t servo;
 
 void SRV_Init() {
 	servo.position = 0;
-	servo.setPosition = 0;
+	servo.setPosition = 1;
 
 	servo.servo.attach(PIN_SRV);
 	delay(1000);

--- a/Arduino/Test_Servo_x2/Servo2.ino
+++ b/Arduino/Test_Servo_x2/Servo2.ino
@@ -6,7 +6,7 @@ Servo_t servo2;
 
 void SRV2_Init() {
 	servo2.position = 0;
-	servo2.setPosition = 1;
+	servo2.setPosition = 1; // servo2.setPosition = 0 にするとサーボが振動してしまうため1で初期化している
 
 	servo2.servo.attach(PIN_SRV2);
 	delay(1000);

--- a/Arduino/Test_Servo_x2/Servo2.ino
+++ b/Arduino/Test_Servo_x2/Servo2.ino
@@ -6,7 +6,7 @@ Servo_t servo2;
 
 void SRV2_Init() {
 	servo2.position = 0;
-	servo2.setPosition = 0;
+	servo2.setPosition = 1;
 
 	servo2.servo.attach(PIN_SRV2);
 	delay(1000);


### PR DESCRIPTION
### 概要
- Fix: サーボ関係の初期化関数の微修正

### 詳細
- サーボを初期化する際に`servo.setPosition = 0`にして`SRV_Run()`を行っているが，`servo.setPosition = 0`でRunするとサーボが細かく振動するので，`servo.setPosition = 1`にしてRunするように変更した